### PR TITLE
Update community deps and remove npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,14 @@
         "@types/fs-extra": "^9.0.13",
         "@types/lodash": "^4.17.13",
         "@types/node": "^18.7.16",
-        "brighterscript": "^0.70.3",
+        "brighterscript": "^0.72.2",
         "dotenv": "^16.4.5",
         "fast-glob": "^3.2.12",
         "fs-extra": "^10.1.0",
         "lodash": "^4.18.1",
         "node-fetch": "^2.7.0",
-        "rooibos-roku": "^5.15.7",
-        "ropm": "^0.11.4",
+        "rooibos-roku": "^5.16.3",
+        "ropm": "^0.11.7",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.3"
       }
@@ -377,26 +377,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@xml-tools/ast": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
-      "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
-      "dev": true,
-      "dependencies": {
-        "@xml-tools/common": "^0.1.6",
-        "@xml-tools/parser": "^1.0.11",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@xml-tools/common": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
-      "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "4.17.21"
-      }
-    },
     "node_modules/@xml-tools/parser": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
@@ -639,14 +619,14 @@
       }
     },
     "node_modules/brighterscript": {
-      "version": "0.70.4",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.70.4.tgz",
-      "integrity": "sha512-obqwoJgdGwnQPxxNywq1uMxYTQs4vZsP3cJ5Pftwtq6asm0QE0YLLB2D0EB9DqX6NSFfSK0e+UqFkuKkzqeydg==",
+      "version": "0.72.2",
+      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.72.2.tgz",
+      "integrity": "sha512-hCAVU+VHjYrbR+zO+vVutBpkSRujjkYr4ra82GYmFKRArGiJfKdMgOh/gJGF3R1vUDUHUmLoEzuKI08w+hqBnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rokucommunity/bslib": "^0.1.1",
-        "@rokucommunity/logger": "^0.3.11",
+        "@rokucommunity/logger": "^0.3.12",
         "@xml-tools/parser": "^1.0.7",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^2.4.2",
@@ -671,8 +651,9 @@
         "parse-ms": "^2.1.0",
         "readline": "^1.3.0",
         "require-relative": "^0.8.7",
-        "roku-deploy": "^3.16.3",
+        "roku-deploy": "^3.17.4",
         "safe-json-stringify": "^1.2.0",
+        "semver": "^7.7.3",
         "serialize-error": "^7.0.1",
         "source-map": "^0.7.4",
         "thenby": "^1.3.4",
@@ -2628,89 +2609,6 @@
         "roku-debug": "dist/cli.js"
       }
     },
-    "node_modules/roku-debug/node_modules/brighterscript": {
-      "version": "0.72.2",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.72.2.tgz",
-      "integrity": "sha512-hCAVU+VHjYrbR+zO+vVutBpkSRujjkYr4ra82GYmFKRArGiJfKdMgOh/gJGF3R1vUDUHUmLoEzuKI08w+hqBnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rokucommunity/bslib": "^0.1.1",
-        "@rokucommunity/logger": "^0.3.12",
-        "@xml-tools/parser": "^1.0.7",
-        "array-flat-polyfill": "^1.0.1",
-        "chalk": "^2.4.2",
-        "chevrotain": "^7.0.1",
-        "chokidar": "^3.6.0",
-        "clear": "^0.1.0",
-        "cross-platform-clear-console": "^2.3.0",
-        "debounce-promise": "^3.1.0",
-        "eventemitter3": "^4.0.0",
-        "fast-glob": "^3.2.12",
-        "file-url": "^3.0.0",
-        "fs-extra": "^8.1.0",
-        "ignore": "^5.3.1",
-        "jsonc-parser": "^2.3.0",
-        "lodash.isequal": "^4.5.0",
-        "long": "^3.2.0",
-        "luxon": "^2.5.2",
-        "micromatch": "^4.0.4",
-        "minimatch": "^3.0.4",
-        "moment": "^2.23.0",
-        "p-settle": "^2.1.0",
-        "parse-ms": "^2.1.0",
-        "readline": "^1.3.0",
-        "require-relative": "^0.8.7",
-        "roku-deploy": "^3.17.4",
-        "safe-json-stringify": "^1.2.0",
-        "semver": "^7.7.3",
-        "serialize-error": "^7.0.1",
-        "source-map": "^0.7.4",
-        "thenby": "^1.3.4",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-protocol": "^3.17.5",
-        "vscode-languageserver-textdocument": "^1.0.11",
-        "vscode-languageserver-types": "^3.17.5",
-        "vscode-uri": "^3.0.8",
-        "xml2js": "^0.5.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "bsc": "dist/cli.js",
-        "bsc0": "dist/cli.js"
-      }
-    },
-    "node_modules/roku-debug/node_modules/brighterscript/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/roku-debug/node_modules/brighterscript/node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/roku-debug/node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -2734,16 +2632,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/roku-debug/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/roku-debug/node_modules/jsprim": {
@@ -2837,16 +2725,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/roku-debug/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/roku-debug/node_modules/uuid": {
@@ -3022,127 +2900,27 @@
       "dev": true
     },
     "node_modules/rooibos-roku": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/rooibos-roku/-/rooibos-roku-5.16.2.tgz",
-      "integrity": "sha512-ii8XB5aOXC24Gkglx576J2KCeSEdm+ys5bbaDYPp4f/51GG5W1XW5flzmHcUnbCGVumsyLBcwhhNabh6lreqwA==",
+      "version": "5.16.3",
+      "resolved": "https://registry.npmjs.org/rooibos-roku/-/rooibos-roku-5.16.3.tgz",
+      "integrity": "sha512-dI7hV+OdpC9VtH82+EQY8rOfzQrD7N73ntMjsKmGjqV9O5DRpapB0E0VAJqaUaqeJ3bR7TmAY7LKKEO/QVLpqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "brighterscript": "^0.72.1",
+        "brighterscript": "^0.72.2",
         "fast-glob": "^3.2.12",
         "fs-extra": "^10.1.0",
         "minimatch": "^3.0.4",
-        "roku-debug": "^0.23.6",
-        "roku-deploy": "^3.17.2",
+        "roku-debug": "^0.23.8",
+        "roku-deploy": "^3.17.4",
         "rooibos_promises": "npm:@rokucommunity/promises@^0.5.0",
         "source-map": "^0.7.3",
-        "undent": "^0.1.0",
+        "undent": "^1.0.1",
         "vscode-languageserver": "~6.1.1",
         "vscode-languageserver-protocol": "~3.17.5",
         "yargs": "^16.2.0"
       },
       "bin": {
         "rooibos": "dist/cli.js"
-      }
-    },
-    "node_modules/rooibos-roku/node_modules/brighterscript": {
-      "version": "0.72.2",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.72.2.tgz",
-      "integrity": "sha512-hCAVU+VHjYrbR+zO+vVutBpkSRujjkYr4ra82GYmFKRArGiJfKdMgOh/gJGF3R1vUDUHUmLoEzuKI08w+hqBnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rokucommunity/bslib": "^0.1.1",
-        "@rokucommunity/logger": "^0.3.12",
-        "@xml-tools/parser": "^1.0.7",
-        "array-flat-polyfill": "^1.0.1",
-        "chalk": "^2.4.2",
-        "chevrotain": "^7.0.1",
-        "chokidar": "^3.6.0",
-        "clear": "^0.1.0",
-        "cross-platform-clear-console": "^2.3.0",
-        "debounce-promise": "^3.1.0",
-        "eventemitter3": "^4.0.0",
-        "fast-glob": "^3.2.12",
-        "file-url": "^3.0.0",
-        "fs-extra": "^8.1.0",
-        "ignore": "^5.3.1",
-        "jsonc-parser": "^2.3.0",
-        "lodash.isequal": "^4.5.0",
-        "long": "^3.2.0",
-        "luxon": "^2.5.2",
-        "micromatch": "^4.0.4",
-        "minimatch": "^3.0.4",
-        "moment": "^2.23.0",
-        "p-settle": "^2.1.0",
-        "parse-ms": "^2.1.0",
-        "readline": "^1.3.0",
-        "require-relative": "^0.8.7",
-        "roku-deploy": "^3.17.4",
-        "safe-json-stringify": "^1.2.0",
-        "semver": "^7.7.3",
-        "serialize-error": "^7.0.1",
-        "source-map": "^0.7.4",
-        "thenby": "^1.3.4",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-protocol": "^3.17.5",
-        "vscode-languageserver-textdocument": "^1.0.11",
-        "vscode-languageserver-types": "^3.17.5",
-        "vscode-uri": "^3.0.8",
-        "xml2js": "^0.5.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "bsc": "dist/cli.js",
-        "bsc0": "dist/cli.js"
-      }
-    },
-    "node_modules/rooibos-roku/node_modules/brighterscript/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/rooibos-roku/node_modules/brighterscript/node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/rooibos-roku/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/rooibos-roku/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/rooibos-roku/node_modules/vscode-languageserver": {
@@ -3158,22 +2936,21 @@
       }
     },
     "node_modules/ropm": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.6.tgz",
-      "integrity": "sha512-4xVAAIGRsf3OqeJ/nTtvC3wqnyIf/lnluLQ0syEhBqdsQuikLhqstL/gi9e/86f/oORc5isoRC+/huvqtOoDWQ==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.7.tgz",
+      "integrity": "sha512-J+gazn70Dj87Jr4sqwmclwCA+baQSr7VstZL+ypDBl6IIOcpZEF8Ejtdc2XmuyUsDXbbQnlWUUl8rnqEkgmWow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rokucommunity/logger": "^0.3.11",
-        "@xml-tools/ast": "^5.0.5",
+        "@rokucommunity/logger": "^0.3.12",
         "@xml-tools/parser": "1.0.10",
-        "brighterscript": "^0.72.1",
+        "brighterscript": "^0.72.2",
         "del": "6.0.0",
         "fs-extra": "9.1.0",
         "glob-all": "3.2.1",
         "latinize": "0.5.0",
         "npm-packlist": "2.1.4",
-        "roku-deploy": "^3.17.2",
+        "roku-deploy": "^3.17.4",
         "semver": "^7.6.3",
         "yargs": "16.2.0"
       },
@@ -3191,93 +2968,6 @@
       "dev": true,
       "dependencies": {
         "chevrotain": "7.1.1"
-      }
-    },
-    "node_modules/ropm/node_modules/brighterscript": {
-      "version": "0.72.2",
-      "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.72.2.tgz",
-      "integrity": "sha512-hCAVU+VHjYrbR+zO+vVutBpkSRujjkYr4ra82GYmFKRArGiJfKdMgOh/gJGF3R1vUDUHUmLoEzuKI08w+hqBnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rokucommunity/bslib": "^0.1.1",
-        "@rokucommunity/logger": "^0.3.12",
-        "@xml-tools/parser": "^1.0.7",
-        "array-flat-polyfill": "^1.0.1",
-        "chalk": "^2.4.2",
-        "chevrotain": "^7.0.1",
-        "chokidar": "^3.6.0",
-        "clear": "^0.1.0",
-        "cross-platform-clear-console": "^2.3.0",
-        "debounce-promise": "^3.1.0",
-        "eventemitter3": "^4.0.0",
-        "fast-glob": "^3.2.12",
-        "file-url": "^3.0.0",
-        "fs-extra": "^8.1.0",
-        "ignore": "^5.3.1",
-        "jsonc-parser": "^2.3.0",
-        "lodash.isequal": "^4.5.0",
-        "long": "^3.2.0",
-        "luxon": "^2.5.2",
-        "micromatch": "^4.0.4",
-        "minimatch": "^3.0.4",
-        "moment": "^2.23.0",
-        "p-settle": "^2.1.0",
-        "parse-ms": "^2.1.0",
-        "readline": "^1.3.0",
-        "require-relative": "^0.8.7",
-        "roku-deploy": "^3.17.4",
-        "safe-json-stringify": "^1.2.0",
-        "semver": "^7.7.3",
-        "serialize-error": "^7.0.1",
-        "source-map": "^0.7.4",
-        "thenby": "^1.3.4",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-protocol": "^3.17.5",
-        "vscode-languageserver-textdocument": "^1.0.11",
-        "vscode-languageserver-types": "^3.17.5",
-        "vscode-uri": "^3.0.8",
-        "xml2js": "^0.5.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "bsc": "dist/cli.js",
-        "bsc0": "dist/cli.js"
-      }
-    },
-    "node_modules/ropm/node_modules/brighterscript/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/ropm/node_modules/brighterscript/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/ropm/node_modules/brighterscript/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/ropm/node_modules/chevrotain": {
@@ -3784,10 +3474,11 @@
       }
     },
     "node_modules/undent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/undent/-/undent-0.1.0.tgz",
-      "integrity": "sha512-vohX7ywgBjRxDNw+f3wHclSXmO0z9HsEfmGObOuG7G0yi7kZ6OtCG8kAxtDSNklmua5KR6ev2drTFqMGqpYEbg==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/undent/-/undent-1.0.1.tgz",
+      "integrity": "sha512-tmOp1rx427j97ggcALIuRdCLUTpzVPdKS4JIcWykq9mymOFGY4jhhNIcYj9zicL8xdBPDHRiOWe0jhNIT0mUQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
   },
   "author": "Tyler Smith",
   "license": "MIT",
-  "overrides": {
-    "lodash": "^4.18.1",
-    "serialize-javascript": "^7.0.5"
-  },
   "ropm": {
     "packagePrefix": "sgRouter",
     "packageRootDir": "dist",
@@ -42,14 +38,14 @@
     "@types/fs-extra": "^9.0.13",
     "@types/lodash": "^4.17.13",
     "@types/node": "^18.7.16",
-    "brighterscript": "^0.70.3",
+    "brighterscript": "^0.72.2",
     "dotenv": "^16.4.5",
     "fast-glob": "^3.2.12",
     "fs-extra": "^10.1.0",
     "lodash": "^4.18.1",
     "node-fetch": "^2.7.0",
-    "rooibos-roku": "^5.15.7",
-    "ropm": "^0.11.4",
+    "rooibos-roku": "^5.16.3",
+    "ropm": "^0.11.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3"
   },


### PR DESCRIPTION
## Summary
- Removed the `lodash` / `serialize-javascript` `overrides` block — updated `ropm` and `rooibos-roku` no longer pull in the vulnerable transitive package, so the manual pins are no longer needed.
- Bumped community dev deps: `brighterscript` `^0.70.3` → `^0.72.2`, `ropm` `^0.11.4` → `^0.11.7`, `rooibos-roku` `^5.15.7` → `^5.16.3`.
- `npm audit` reports 0 vulnerabilities after the update.