### PR TITLE
Use routeConfig instead of routeParams check for component reuse

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ roku_modules
 *.tgz
 *.json
 *.spec.brs
+*.spec.xml

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,7 +5,8 @@
 		"source/**/*",
 		"components/**/*",
 		//exclude all test files files.
-		"!**/*.spec.bs"
+		"!**/*.spec.bs",
+		"!**/*.spec.xml"
 	],
 	"emitDefinitions": true,
 	"createPackage": false,

--- a/src/components/AlternateView.spec.xml
+++ b/src/components/AlternateView.spec.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="AlternateView" extends="View" />

--- a/src/components/Router.bs
+++ b/src/components/Router.bs
@@ -424,7 +424,7 @@ function _navigateTo(path = "" as Dynamic, options = {} as Object) as Dynamic
                 if hasHash then
                     if NOT rodash.isEqual(newRoute.routeConfig, oldRoute.routeConfig) then reuse = false
                 else
-                    if NOT rodash.isEqual(newRoute.routeParams.component, oldRoute.routeParams.component) then reuse = false
+                    if NOT rodash.isEqual(newRoute.routeConfig.component, oldRoute.routeConfig.component) then reuse = false
                 end if
 
                 if reuse then

--- a/src/source/router.spec.bs
+++ b/src/source/router.spec.bs
@@ -410,6 +410,26 @@ namespace tests
             end function).toPromise()
         end function
 
+        @async()
+        @it("creates a new view when navigating to an allowReuse route with a different component")
+        function _() 'bs:disable-line 1026 LINT1026
+            m.router@._initialize({ outlet: m.outlet })
+            m.router@._addRoutes([
+                { pattern: "/alpha", component: "View", allowReuse: true }
+                { pattern: "/beta", component: "AlternateView", allowReuse: true }
+            ])
+
+            return promises.chain(sgRouter.navigateTo("/alpha", { router: m.router }), m).then(function(_, m)
+                return sgRouter.navigateTo("/beta", { router: m.router })
+            end function).then(function(_, m)
+                viewTarget = m.outlet.findNode("viewTarget")
+
+                m.assertEqual(viewTarget.getChildCount(), 2)
+                m.assertEqual(viewTarget.getChild(1).subtype(), "AlternateView")
+                m.assertEqual(m.router.routerState.url, "/beta")
+            end function).toPromise()
+        end function
+
         '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         @describe("concurrent navigation")
         '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/test-project/bsconfig.json
+++ b/test-project/bsconfig.json
@@ -19,7 +19,8 @@
 			"dest": "components"
 		},
 		//exclude the test files
-		"!../src/**/*.spec.bs"
+		"!../src/**/*.spec.bs",
+		"!../src/**/*.spec.xml"
 	],
 	"plugins": []
 }


### PR DESCRIPTION
Fixes a view reuse bug where the router was checking the wrong value when deciding whether an existing view could be reused. The decision was based on route params instead of the configured route component, which could allow navigation between different screens to reuse the same view instance incorrectly.

The fix compares `routeConfig.component` for the current and next routes, so reuse only happens when the route is still targeting the same component.