### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -671,9 +671,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1903,9 +1903,9 @@
       "dev": true
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "packageRootDir": "dist",
     "rootDir": "src"
   },
+  "overrides": {
+    "brace-expansion@^1": "^1.1.18",
+    "ip-address": "^10.3.1"
+  },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/lodash": "^4.17.13",


### PR DESCRIPTION
Clears the two high-severity advisories that were failing `npm run audit`.

`npm audit --omit=dev`: **0 vulnerabilities** across the 2 runtime deps (`promises`, `rodash`) — consumers were never exposed by any of these. Full audit went 5 → 3, with zero high remaining (the 3 are all below the gate's `high` floor).

## Ships to consumers

Nothing. Both advisories are dev-only, and the `overrides` block added here is not inherited by consumers.

## Lockfile only (dev deps)

Both are dev-only transitives with no fixed parent release, so `overrides` is the only lever. `brace-expansion` is pinned to its v1 line since that's the only major present.

| Package | Via | Was | Now |
|---|---|---|---|
| `brace-expansion` | `rooibos-roku`→`minimatch@3` | 1.1.14 | `^1.1.18` |
| `ip-address` | `brighterscript`→`roku-deploy`→`postman-request`→`socks` | 10.2.0 | `^10.3.1` |

## Notes for the reviewer

- The 3 remaining advisories (`qs`, `uuid`) are moderate and don't fail the gate. The `uuid` `audit-ci.jsonc` allowlist entry is kept as-is.
- `npm run test` needs a real Roku device, so it wasn't run here; `preversion` (ropm copy + bsc compile + dist build) is the full offline gate and passes.

## Verification

`npm run preversion` passes — ropm copy, `bsc` compile with no diagnostics, and dist build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
